### PR TITLE
Canon bulb modus

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/GPCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/GPCamera.cs
@@ -437,8 +437,24 @@ namespace NINA.Equipment.Equipment.MyCamera {
         }
 
         private bool IsBulbMode() {
+            // Check if camera is in dedicated Bulb mode (autoexposuremode = "Bulb")
+            var mode = string.Empty;
+            if (GetProperty("exposuremode", out mode) == GP_ERROR_CODE.GP_OK) {
+                if (mode.Equals("Bulb", StringComparison.OrdinalIgnoreCase)) {
+                    return true;
+                }
+            }
+            if (GetProperty("autoexposuremode", out mode) == GP_ERROR_CODE.GP_OK) {
+                if (mode.Equals("Bulb", StringComparison.OrdinalIgnoreCase)) {
+                    return true;
+                }
+            }
+
+            // Check if camera is in Manual mode with bulb shutter speed
             if (!CheckError(GetProperty("shutterspeed", out var shutterspeed))) {
-                return shutterspeed.Equals("bulb", StringComparison.OrdinalIgnoreCase);
+                if (shutterspeed.Equals("bulb", StringComparison.OrdinalIgnoreCase)) {
+                    return true;
+                }
             }
 
             // If bulb mode is not set, try to set it
@@ -739,11 +755,13 @@ namespace NINA.Equipment.Equipment.MyCamera {
                 }
             }
 
-            if (IsManualMode()) {
+            if (IsManualMode() && !IsBulbMode()) {
+                // Camera is in Manual mode but NOT in bulb shutter speed
                 GetShutterSpeeds();
                 if (exposureTime <= 30.0) {
                     SetExposureTime(exposureTime);
                 } else {
+                    // Need bulb mode for exposures > 30s
                     var success = SetExposureTime(double.MaxValue);
                     Logger.Info("CHECKING");
                     if (!success) {

--- a/NINA.Equipment/Equipment/MyCamera/GPCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/GPCamera.cs
@@ -724,35 +724,17 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
         private void ValidateMode() {
             if (!IsManualMode() && !IsBulbMode()) {
-                var result = MyMessageBox.Show(
-                    Loc.Instance["LblEDCameraNotInManualMode"],
-                    Loc.Instance["LblInvalidMode"],
-                    System.Windows.MessageBoxButton.OKCancel,
-                    System.Windows.MessageBoxResult.OK);
-                if (result == System.Windows.MessageBoxResult.OK) {
-                    ValidateMode();
-                } else {
-                    Notification.ShowError("Camera must be in MANUAL or BULB mode");
-                    Logger.Error("Camera must be in MANUAL or BULB mode");
-                    throw new Exception("Invalid camera mode");
-                }
+                Notification.ShowError("Camera must be in MANUAL or BULB mode");
+                Logger.Error("Camera must be in MANUAL or BULB mode");
+                throw new Exception("Invalid camera mode");
             }
         }
 
         private void ValidateModeForExposure(double exposureTime) {
             if (!IsManualMode() && !IsBulbMode()) {
-                var result = MyMessageBox.Show(
-                    Loc.Instance["LblEDCameraNotInManualMode"],
-                    Loc.Instance["LblInvalidMode"],
-                    System.Windows.MessageBoxButton.OKCancel,
-                    System.Windows.MessageBoxResult.OK);
-                if (result == System.Windows.MessageBoxResult.OK) {
-                    ValidateModeForExposure(exposureTime);
-                } else {
-                    Notification.ShowError("Camera must be in MANUAL or BULB mode");
-                    Logger.Error("Camera must be in MANUAL or BULB mode");
-                    throw new Exception("Invalid camera mode for taking exposures");
-                }
+                Notification.ShowError("Camera must be in MANUAL or BULB mode");
+                Logger.Error("Camera must be in MANUAL or BULB mode");
+                throw new Exception("Invalid camera mode for taking exposures");
             }
 
             if (IsManualMode() && !IsBulbMode()) {
@@ -762,38 +744,23 @@ namespace NINA.Equipment.Equipment.MyCamera {
                     SetExposureTime(exposureTime);
                 } else {
                     // Need bulb mode for exposures > 30s
-                    var success = SetExposureTime(double.MaxValue);
-                    Logger.Info("CHECKING");
-                    if (!success) {
-                        Logger.Info("GOING IN THE NON SUCCESS PART");
-                        var result = MyMessageBox.Show(
-                            Loc.Instance["LblChangeToBulbMode"],
-                            Loc.Instance["LblInvalidModeManual"],
-                            System.Windows.MessageBoxButton.OKCancel,
-                            System.Windows.MessageBoxResult.OK);
-                        if (result == System.Windows.MessageBoxResult.OK) {
-                            ValidateModeForExposure(exposureTime);
-                        } else {
-                            Notification.ShowError("Camera must be in MANUAL or BULB mode");
-                            Logger.Error("Camera must be in MANUAL or BULB mode");
-                            throw new Exception("Invalid camera mode [Manual] for taking bulb exposures");
-                        }
+                    // Try to set shutterspeed to "bulb"
+                    Logger.Info($"Exposure time {exposureTime}s > 30s, attempting to set shutter speed to bulb");
+                    if (CheckError(SetProperty("shutterspeed", "bulb"))) {
+                        Notification.ShowError("Camera must be set to BULB mode for exposures > 30s. Please set shutterspeed to 'bulb' manually.");
+                        Logger.Error("Could not set shutterspeed to bulb for long exposure");
+                        throw new Exception("Invalid camera mode [Manual] for taking bulb exposures");
                     }
                 }
             }
 
             if (IsBulbMode() && exposureTime < 1.0) {
-                var result = MyMessageBox.Show(
-                    Loc.Instance["LblChangeToManualMode"],
-                    Loc.Instance["LblInvalidModeBulb"],
-                    System.Windows.MessageBoxButton.OKCancel,
-                    System.Windows.MessageBoxResult.OK);
-                if (result == System.Windows.MessageBoxResult.OK) {
-                    ValidateModeForExposure(exposureTime);
-                } else {
-                    Notification.ShowError("Cannot use BULB mode for exposures less than 1s");
-                    Logger.Error("Cannot use BULB mode for exposures less than 1s");
-                    throw new Exception("Invalid camera mode [Bulb] for taking exposures < 1s");
+                // Try to switch from bulb to a normal shutter speed for short exposures
+                Logger.Info($"Camera is in bulb mode but exposure time is {exposureTime}s (< 1s). Attempting to set shutter speed.");
+                GetShutterSpeeds();
+                if (!SetExposureTime(exposureTime)) {
+                    Logger.Warning($"Could not set exposure time to {exposureTime}s. Camera may need to be switched from Bulb mode manually.");
+                    Notification.ShowWarning($"Camera is in Bulb mode. For exposures < 1s, please switch to Manual mode or use exposure time >= 1s.");
                 }
             }
         }

--- a/NINA.INDI/Devices/INDITelescope.cs
+++ b/NINA.INDI/Devices/INDITelescope.cs
@@ -266,7 +266,31 @@ namespace NINA.INDI.Devices {
             return modes;
         }
 
-        public DateTime UTCDate { get; set; }
+        public DateTime UTCDate {
+            get {
+                try {
+                    // Read UTC from TIME_UTC property
+                    var utcTime = GetTextPropertyValue("TIME_UTC", "UTC");
+                    if (!string.IsNullOrEmpty(utcTime) && DateTime.TryParse(utcTime, out var parsedTime)) {
+                        return DateTime.SpecifyKind(parsedTime, DateTimeKind.Utc);
+                    }
+                } catch (Exception ex) {
+                    Logger.Warning($"Could not read TIME_UTC: {ex.Message}");
+                }
+                return DateTime.MinValue;
+            }
+            set {
+                try {
+                    // Set UTC time via TIME_UTC property in ISO 8601 format
+                    var utcString = value.ToString("yyyy-MM-ddTHH:mm:ss");
+                    SetTextValue("TIME_UTC", "UTC", utcString);
+                    Logger.Debug($"Set mount UTC time to {utcString}");
+                } catch (Exception ex) {
+                    Logger.Error($"Could not set TIME_UTC: {ex.Message}");
+                    throw;
+                }
+            }
+        }
 
 
         public void AbortSlew() {

--- a/NINA.INDI/INDIClient.cs
+++ b/NINA.INDI/INDIClient.cs
@@ -89,6 +89,7 @@ namespace NINA.INDI {
             { "indi_lx200_TeenAstro", "TeenAstro Mount (INDI)" },
             { "indi_eqmod_telescope", "EQMOD Mount (INDI)" },
             { "indi_synscan_telescope", "Synscan Mount (INDI)" },
+            { "indi_lx200_OnStep", "OnStep Mount (INDI)" },
 
             /* Filter Wheels */
             { "indi_pegasusindigo_wheel", "Pegasus Indigo (INDI)" },


### PR DESCRIPTION
## Summary
Fixes bulb mode detection for Canon cameras during long exposures over 30 seconds.

## Problem
For Canon cameras (e.g. EOS 1300D), bulb mode was not correctly detected when the camera was in manual mode (M) with shutter speed set to "bulb". This caused incorrect warnings for exposure times > 30s.

## Solution
- `IsBulbMode()` now detects both variants:
  - Dedicated bulb mode (`autoexposuremode = "Bulb"`)
  - Manual mode with bulb shutter speed (`autoexposuremode = "Manual"` + `shutterspeed = "bulb"`)
- `ValidateModeForExposure()` skips the bulb warning when already in bulb mode
