### PR TITLE
Add a central script to pull submodules

### DIFF
--- a/pull_submodules.sh
+++ b/pull_submodules.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+excluded_path="NINA/External"
+while read -r _ path; do
+  if [ "$path" = "$excluded_path" ]; then
+    echo "Skipping submodule $path"
+    continue
+  fi
+
+  echo "Updating submodule $path"
+  if git submodule update --init --recursive --remote "$path"; then
+    continue
+  fi
+
+  echo "Remote update failed for $path; falling back to pinned commit" >&2
+  git submodule update --init --recursive "$path"
+done < <(git config -f .gitmodules --get-regexp '^submodule\..*\.path$')


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

While this is not completely necessary
it will help with automated builds, for
example PKGBUILD builds for Arch.

Based on https://github.com/acocalypso/pins/blob/develop/BUILD_PINS.md

## 🧪 How Was It Tested?

Running the script, all submodules have been pulled


