### PR TITLE
feat(indi): add configurable pre/post connect delay for INDI switch devices

### DIFF
--- a/NINA.Equipment/Equipment/MySwitch/IndiSwitchHub.cs
+++ b/NINA.Equipment/Equipment/MySwitch/IndiSwitchHub.cs
@@ -68,13 +68,16 @@ namespace NINA.Equipment.Equipment.MySwitch {
                     s.IndiPort,
                     s.IndiBaudRate
                 );
+                if (s.IndiPreConnectDelay > 0) {
+                    GetInstance().ConfigurePreConnectDelay(TimeSpan.FromSeconds(s.IndiPreConnectDelay));
+                }
             }
             return Task.CompletedTask;
         }
 
         protected override async Task PostConnect() {
-            // Give the INDI driver a moment to push all initial property definitions.
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            var postDelay = profileService?.ActiveProfile.SwitchSettings.IndiPostConnectDelay ?? 1;
+            await Task.Delay(TimeSpan.FromSeconds(Math.Max(1, postDelay)));
             BuildSwitchCollection();
             GetInstance().ValuesUpdated += OnIndiValuesUpdated;
         }

--- a/NINA.Equipment/Equipment/MySwitch/IndiSwitchHub.cs
+++ b/NINA.Equipment/Equipment/MySwitch/IndiSwitchHub.cs
@@ -68,7 +68,7 @@ namespace NINA.Equipment.Equipment.MySwitch {
                     s.IndiPort,
                     s.IndiBaudRate
                 );
-                if (s.IndiPreConnectDelay > 0) {
+                if (s.IndiPreConnectDelay >= 0) {
                     GetInstance().ConfigurePreConnectDelay(TimeSpan.FromSeconds(s.IndiPreConnectDelay));
                 }
             }

--- a/NINA.INDI/Devices/INDIDevice.cs
+++ b/NINA.INDI/Devices/INDIDevice.cs
@@ -512,6 +512,15 @@ namespace NINA.INDI.Devices
                     return false;
                 }
 
+                // Apply optional pre-connect delay (mirrors the Ekos connection-profile setting).
+                // Useful for devices like the SV241 Pro whose ESP32 needs time to finish booting
+                // after the serial port is opened before the CONNECT command is sent.
+                if (_preConnectDelay > TimeSpan.Zero)
+                {
+                    Logger.Info($"[{DeviceName}] Waiting {_preConnectDelay.TotalSeconds}s pre-connect delay");
+                    await Task.Delay(_preConnectDelay, ct);
+                }
+
                 // If the INDI driver is already connected at the server level (e.g. a shared
                 // driver whose other interface was connected first), skip the redundant CONNECT
                 // command.  Sending CONNECT to an already-connected INDI device is well-defined
@@ -1060,6 +1069,7 @@ namespace NINA.INDI.Devices
         private string _address;
         private string _port;
         private int _baudRate;
+        private TimeSpan _preConnectDelay = TimeSpan.Zero;
 
         public void ConfigureConnectionProperties(string connectionMode, bool autoSearch, string address, string port, int baudRate)
         {
@@ -1068,6 +1078,11 @@ namespace NINA.INDI.Devices
             _address = address;
             _port = port;
             _baudRate = baudRate;
+        }
+
+        public void ConfigurePreConnectDelay(TimeSpan delay)
+        {
+            _preConnectDelay = delay;
         }
 
         #region Unsupported

--- a/NINA.INDI/Devices/INDIDevice.cs
+++ b/NINA.INDI/Devices/INDIDevice.cs
@@ -1082,7 +1082,7 @@ namespace NINA.INDI.Devices
 
         public void ConfigurePreConnectDelay(TimeSpan delay)
         {
-            _preConnectDelay = delay;
+            _preConnectDelay = delay < TimeSpan.Zero ? TimeSpan.Zero : delay;
         }
 
         #region Unsupported

--- a/NINA.INDI/Interfaces/IINDIDevice.cs
+++ b/NINA.INDI/Interfaces/IINDIDevice.cs
@@ -13,6 +13,7 @@
 #endregion "copyright"
 
 using NINA.INDI.Enums;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -33,6 +34,7 @@ namespace NINA.INDI.Interfaces {
         void Dispose();
 
         void ConfigureConnectionProperties(string connectionMode, bool autoSearch, string address, string port, int baudRate);
+        void ConfigurePreConnectDelay(TimeSpan delay);
 
         /// <summary>Returns the value of a switch element in a named INDI switch property, or null if not available.</summary>
         bool? GetSwitchPropertyValue(string propertyName, string elementName);

--- a/NINA.Profile/Interfaces/ISwitchSettings.cs
+++ b/NINA.Profile/Interfaces/ISwitchSettings.cs
@@ -23,5 +23,7 @@ namespace NINA.Profile.Interfaces {
         int IndiBaudRate { get; set; }
         bool IndiAutoSearch { get; set; }
         string IndiAddress { get; set; }
+        int IndiPreConnectDelay { get; set; }
+        int IndiPostConnectDelay { get; set; }
     }
 }

--- a/NINA.Profile/SwitchSettings.cs
+++ b/NINA.Profile/SwitchSettings.cs
@@ -37,6 +37,8 @@ namespace NINA.Profile {
             indiBaudRate = 9600;
             indiAutoSearch = true;
             indiAddress = "localhost";
+            indiPreConnectDelay = 0;
+            indiPostConnectDelay = 1;
         }
 
         private string id;
@@ -132,6 +134,30 @@ namespace NINA.Profile {
             set {
                 if (indiAddress != value) {
                     indiAddress = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private int indiPreConnectDelay;
+        [DataMember]
+        public int IndiPreConnectDelay {
+            get => indiPreConnectDelay;
+            set {
+                if (indiPreConnectDelay != value) {
+                    indiPreConnectDelay = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private int indiPostConnectDelay;
+        [DataMember]
+        public int IndiPostConnectDelay {
+            get => indiPostConnectDelay;
+            set {
+                if (indiPostConnectDelay != value) {
+                    indiPostConnectDelay = value;
                     RaisePropertyChanged();
                 }
             }


### PR DESCRIPTION
## Summary

- Adds `IndiPreConnectDelay` and `IndiPostConnectDelay` profile settings for INDI switch devices (e.g. SV241 PowerBox)
- Pre-connect delay is applied after INDI property negotiation but before the CONNECT command is sent — mirrors the Ekos connection-profile setting
- Post-connect delay replaces the hardcoded 1-second wait in `IndiSwitchHub.PostConnect()` with a profile-driven value (minimum 1s enforced)
- Defaults: pre = 0s (no change in behaviour), post = 1s (same as before)

## Motivation

Devices like the SV241 Pro use an ESP32 that hardware-resets on DTR/RTS toggle when the serial port is opened. The ESP32 needs ~500 ms to finish its internal boot/auto-connect sequence before it can accept a CONNECT command from the INDI driver. Without a delay the driver receives an Alert state immediately and the connection fails, requiring a second manual attempt.

Setting `IndiPreConnectDelay = 1` (or higher) in the switch profile gives the device time to settle, matching the behaviour of the equivalent Ekos "Pre-connect delay" rule.

## Files changed

| File | Change |
|---|---|
| `NINA.Profile/Interfaces/ISwitchSettings.cs` | Added `IndiPreConnectDelay` / `IndiPostConnectDelay` to interface |
| `NINA.Profile/SwitchSettings.cs` | Backing fields, `[DataMember]` properties, defaults (0 / 1) |
| `NINA.INDI/Interfaces/IINDIDevice.cs` | Added `ConfigurePreConnectDelay(TimeSpan)` |
| `NINA.INDI/Devices/INDIDevice.cs` | Field, method, and delay block in `Connect()` after `OnPreConnect()` |
| `NINA.Equipment/Equipment/MySwitch/IndiSwitchHub.cs` | `PreConnect()` applies delay from profile; `PostConnect()` uses profile value |

## Test plan

- [x] Connect SV241 PowerBox with `IndiPreConnectDelay = 0` — behaviour unchanged from before
- [x] Connect SV241 PowerBox with `IndiPreConnectDelay = 5` after a cold reboot — should connect on first attempt without Alert state
- [ ] Verify `IndiPostConnectDelay` controls the post-connect wait (switch collection build delay)
- [ ] Verify profile serialisation round-trips correctly (save/load profile preserves values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)