### PR TITLE
Fix relative-only INDI focusers (e.g. HitecAstro DC) failing to move

### DIFF
--- a/NINA.Equipment/Equipment/MyFocuser/IndiFocuser.cs
+++ b/NINA.Equipment/Equipment/MyFocuser/IndiFocuser.cs
@@ -171,7 +171,11 @@ namespace NINA.Equipment.Equipment.MyFocuser {
 
                 var relativeOffsetRemaining = position - this.Position;
                 while (relativeOffsetRemaining != 0 && !ct.IsCancellationRequested) {
-                    var moveAmount = Math.Min(MaxIncrement, Math.Abs(relativeOffsetRemaining));
+                    // MaxIncrement <= 0 means "no known per-move cap" (e.g. no FOCUS_MAX on the
+                    // INDI driver), not "cap every move to zero steps" - move the full remaining
+                    // offset in one shot in that case instead of spinning forever at 0.
+                    var stepCap = MaxIncrement > 0 ? MaxIncrement : Math.Abs(relativeOffsetRemaining);
+                    var moveAmount = Math.Min(stepCap, Math.Abs(relativeOffsetRemaining));
                     if (relativeOffsetRemaining < 0) {
                         moveAmount *= -1;
                     }

--- a/NINA.Equipment/Equipment/MyFocuser/IndiFocuser.cs
+++ b/NINA.Equipment/Equipment/MyFocuser/IndiFocuser.cs
@@ -213,7 +213,20 @@ namespace NINA.Equipment.Equipment.MyFocuser {
 
         private void Initialize() {
             var maxStep = device.MaxStep;
-            internalPosition = maxStep > 0 ? maxStep / 2 : 0;
+            if (maxStep > 0) {
+                internalPosition = maxStep / 2;
+            } else {
+                // MaxStep unknown (no FOCUS_MAX, e.g. a HitecAstro DC) - starting at 0
+                // pins every inward move at 0 too, since MoveFocuserInternal clamps
+                // negative targets back to 0: a fresh connect could move outward but
+                // never inward. Seed a synthetic midpoint instead, using half of
+                // MaxIncrement (which for INDI focusers derives from REL_FOCUS_POSITION's
+                // own reported max when FOCUS_MAX is absent - see INDIFocuser.MaxIncrement)
+                // so there's room to move both directions; fall back to a fixed synthetic
+                // midpoint if even that isn't available.
+                var maxIncrement = device.MaxIncrement;
+                internalPosition = maxIncrement > 0 ? maxIncrement / 2 : 5000;
+            }
             _isAbsolute = device.Absolute;
             if (!_isAbsolute) {
                 Logger.Info("The focuser is a relative focuser. Simulating absolute focuser behavior");

--- a/NINA.INDI/Devices/INDIDevice.cs
+++ b/NINA.INDI/Devices/INDIDevice.cs
@@ -187,6 +187,12 @@ namespace NINA.INDI.Devices
             return prop?.Numbers.FirstOrDefault(n => n.Name == elementName)?.Value;
         }
 
+        public double? GetNumberPropertyMax(string propertyName, string elementName)
+        {
+            var prop = GetNumberProperty(propertyName);
+            return prop?.Numbers.FirstOrDefault(n => n.Name == elementName)?.Max;
+        }
+
         public bool? GetSwitchPropertyValue(string propertyName, string elementName)
         {
             var prop = GetSwitchProperty(propertyName);

--- a/NINA.INDI/Devices/INDIFocuser.cs
+++ b/NINA.INDI/Devices/INDIFocuser.cs
@@ -45,6 +45,15 @@ namespace NINA.INDI.Devices {
                     // Check if moving based on state
                     IsMoving = p.State == PropertyState.Busy;
                     break;
+                case "REL_FOCUS_POSITION":
+                    // Relative-only focusers (e.g. HitecAstro DC) never send ABS_FOCUS_POSITION,
+                    // so Absolute stays false and motion must be tracked from this property's
+                    // state instead. Guarded on !Absolute so it doesn't override the absolute
+                    // path for drivers that expose both properties.
+                    if (!Absolute) {
+                        IsMoving = p.State == PropertyState.Busy;
+                    }
+                    break;
             }
         }
 
@@ -82,7 +91,11 @@ namespace NINA.INDI.Devices {
         }
 
         public int MaxStep {
-            get => (int)(GetNumberPropertyValue("FOCUS_MAX", "FOCUS_MAX_VALUE") ?? 0.0);
+            // -1 (not 0) signals "no known limit" when FOCUS_MAX is absent, matching the
+            // sentinel that CanSetMaxStep-gated callers already expect (e.g. IndiFocuser.MaxStep).
+            // A 0 default here previously made relative-move step chunking collapse to 0 and
+            // spin forever on focusers without FOCUS_MAX (e.g. HitecAstro DC).
+            get => (int)(GetNumberPropertyValue("FOCUS_MAX", "FOCUS_MAX_VALUE") ?? -1.0);
             set {
                 if (!Connected) {
                     Logger.Warning("Cannot set MaxStep: not connected");
@@ -142,9 +155,32 @@ namespace NINA.INDI.Devices {
                 Logger.Warning("Cannot move focuser: not connected");
                 return;
             }
+
             IsMoving = true;
-            SetNumberValue("ABS_FOCUS_POSITION", "FOCUS_ABSOLUTE_POSITION", position);
-            Logger.Info($"Commanded focuser to move to position {position}");
+            try {
+                if (Absolute) {
+                    SetNumberValue("ABS_FOCUS_POSITION", "FOCUS_ABSOLUTE_POSITION", position);
+                    Logger.Info($"Commanded focuser to move to position {position}");
+                } else {
+                    // Relative-only focuser (no ABS_FOCUS_POSITION, e.g. HitecAstro DC).
+                    // IndiFocuser.MoveInternalRelative already computes "position" as a signed
+                    // step delta in this case, not an absolute target - see its Math.Min/sign
+                    // handling. Translate that into this driver's two relative-move properties:
+                    // a direction switch plus an unsigned step count.
+                    if (position == 0) {
+                        IsMoving = false;
+                        return;
+                    }
+                    SetSwitchValue("FOCUS_MOTION", position > 0 ? "FOCUS_OUTWARD" : "FOCUS_INWARD", true);
+                    SetNumberValue("REL_FOCUS_POSITION", "FOCUS_RELATIVE_POSITION", Math.Abs(position));
+                    Logger.Info($"Commanded focuser to move {Math.Abs(position)} steps {(position > 0 ? "outward" : "inward")}");
+                }
+            } catch {
+                // Don't strand IsMoving = true forever if the property write itself fails -
+                // MoveAsync's poll loop has no other way to learn the move never started.
+                IsMoving = false;
+                throw;
+            }
         }
 
         // Ceiling for MoveAsync's poll loop. IsMoving is only ever cleared by a driver update

--- a/NINA.INDI/Devices/INDIFocuser.cs
+++ b/NINA.INDI/Devices/INDIFocuser.cs
@@ -81,7 +81,21 @@ namespace NINA.INDI.Devices {
 
         public bool Absolute { get; private set; }
         public bool IsMoving { get; private set; }
-        public int MaxIncrement => MaxStep;
+
+        public int MaxIncrement {
+            get {
+                if (MaxStep > 0) {
+                    return MaxStep;
+                }
+                // No FOCUS_MAX (MaxStep is the -1 "unknown" sentinel) doesn't mean a
+                // relative move can safely be any size - REL_FOCUS_POSITION carries its
+                // own driver-reported bound (e.g. a HitecAstro DC's own min/max step
+                // range), and IUUpdateNumber rejects writes outside it. Use that instead
+                // of leaving relative-move chunking uncapped.
+                var relMax = GetNumberPropertyMax("REL_FOCUS_POSITION", "FOCUS_RELATIVE_POSITION");
+                return relMax > 0 ? (int)relMax.Value : -1;
+            }
+        }
 
         public bool CanSetMaxStep {
             get {

--- a/NINA.WPF.Base/ViewModel/Equipment/Focuser/FocuserVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Focuser/FocuserVM.cs
@@ -212,7 +212,9 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Focuser {
                 position = 0;
             }
 
-            if (position > Focuser.MaxStep) {
+            // MaxStep == -1 means "unknown/no limit" (e.g. focusers without a FOCUS_MAX INDI
+            // property), not a literal ceiling of -1 - only clamp when a real max is known.
+            if (Focuser.MaxStep > 0 && position > Focuser.MaxStep) {
                 Logger.Warning($"Requested to move to position {position}, which higher than max position. Moving to {Focuser.MaxStep} instead.");
                 position = Focuser.MaxStep;
             }


### PR DESCRIPTION
## Issue

Focusers that have no absolute-position hardware feedback — i.e. no
`ABS_FOCUS_POSITION` INDI property, only relative-move properties
(`FOCUS_MOTION` direction switch + `REL_FOCUS_POSITION` step count) — fail
every move attempt. Reproduced live with a physical **HitecAstro DC**
(`indi_hitecastrodc_focus` driver), connected via USB on a Raspberry Pi:

```
WARNING|FocuserVM.cs|MoveFocuserInternal|Requested to move to position 25, which higher than max position. Moving to -1 instead.
ERROR|FocuserVM.cs|MoveFocuserInternal|Focuser move failed
System.ArgumentException: Number property 'ABS_FOCUS_POSITION' not found
```

Confirmed directly against the running INDI server (`indi_getprop`) that this
driver only ever defines `FOCUS_MOTION` and `REL_FOCUS_POSITION` — no
`ABS_FOCUS_POSITION`, no `FOCUS_MAX`. This is expected: it's a basic
open-loop DC focus motor with no position encoder, not a driver bug.

## Root cause

`IndiFocuser` (`NINA.Equipment/Equipment/MyFocuser/IndiFocuser.cs`) already
has scaffolding for this device class: an `Absolute` flag (true only once an
`ABS_FOCUS_POSITION` update is ever observed) that branches every `Move()`
call into `MoveInternalAbsolute` vs `MoveInternalRelative`. But the low-level
driver, `INDIFocuser` (`NINA.INDI/Devices/INDIFocuser.cs`), never actually
implemented the relative side — `Move()` unconditionally wrote
`ABS_FOCUS_POSITION` no matter which high-level path called it, so the
scaffolding never worked end-to-end for a device like this.

Two more bugs compounded this for any focuser lacking `FOCUS_MAX`:

- `FocuserVM.MoveFocuserInternal`'s max-position clamp treated
  `MaxStep == -1` (the established "unknown, no limit" sentinel used
  elsewhere in the codebase, e.g. `ASIFocuser.MaxStep` on a communication
  error) as a literal ceiling, clamping every requested position down to
  `-1` before the move was even attempted (visible in the log above).
- `INDIFocuser.MaxStep` defaulted to `0`, not `-1`, when `FOCUS_MAX` was
  absent. `IndiFocuser.MoveInternalRelative`'s per-step chunking does
  `Math.Min(MaxIncrement, remainingOffset)`; with `MaxIncrement` pinned at
  `0` this would have collapsed every move to 0 steps and spun forever, even
  after fixing the `ABS_FOCUS_POSITION` write.

A fourth, related bug: `INDIFocuser.Move()` set `IsMoving = true` **before**
the property write that could throw, with no `catch`/`finally` to reset it —
so a single failed move permanently stuck the focuser reporting
`IsMoving: true` (visible via `/v2/api/equipment/focuser/info`) until the
service was restarted.

## Changes

- **`INDIFocuser.Move()`** now branches on `Absolute`. `true` keeps the
  original `ABS_FOCUS_POSITION` write unchanged. `false` sets `FOCUS_MOTION`
  to `FOCUS_OUTWARD`/`FOCUS_INWARD` by sign and writes the magnitude to
  `REL_FOCUS_POSITION` instead. The whole write is wrapped in `try/catch`
  that resets `IsMoving = false` before rethrowing, so a failure can't
  strand the flag.
- **`INDIFocuser.OnNumberPropertyUpdated()`** gained a case for
  `REL_FOCUS_POSITION` that tracks `IsMoving` from that property's
  Busy/Idle state, guarded on `!Absolute` so it can't affect absolute
  focusers that happen to also expose `REL_FOCUS_POSITION`. Without this,
  completion is never observed for a device that never sends
  `ABS_FOCUS_POSITION` updates.
- **`INDIFocuser.MaxStep`** now defaults to `-1` instead of `0` when
  `FOCUS_MAX` is absent, so "unknown" is consistent everywhere it's read.
- **`IndiFocuser.MoveInternalRelative()`** skips the per-step
  `MaxIncrement` cap when `MaxIncrement <= 0` (moves the full remaining
  offset in one step) instead of clamping to a bogus `0`.
- **`FocuserVM.MoveFocuserInternal()`**'s max-position clamp now only
  applies when `Focuser.MaxStep > 0`.

## Scope / why this doesn't affect absolute focusers

- `Move()` takes the exact original code path when `Absolute` is `true` —
  mid-move behavior is byte-for-byte unchanged; only a `catch` was added
  around it.
- `MaxStep`'s changed fallback only takes effect in the null-coalescing
  branch, i.e. only for focusers that don't expose `FOCUS_MAX` at all. Any
  focuser with a real `FOCUS_MAX` value is unaffected.
- `MoveInternalRelative` and the new `REL_FOCUS_POSITION` tracking only run
  when `Absolute` is `false`, which a genuinely absolute focuser never is —
  `Connect()` already blocks up to 20s waiting for `ABS_FOCUS_POSITION` to
  arrive before marking the device connected, so `Absolute` is `true` by
  the time `Move()` can be called.
- Checked every other `IFocuser` implementation (`AscomFocuser`,
  `AlpacaDirectFocuser`, `ASIFocuser`, `NitecrawlerFocuser`,
  `ToupTekAlikeFocuser`, `OasisFocuser`) — none of these files are touched,
  and all but the Alpaca passthrough hardcode `CanSetMaxStep => true` with a
  real hardware-queried max, so the `-1` sentinel handling doesn't apply to
  them either.

## Testing

Verified live against a physical HitecAstro DC (USB, `indi_hitecastrodc_focus`
driver) on a Raspberry Pi running AstroArch:

- Connect: succeeds, `Absolute` correctly resolves to `false` ("The focuser
  is a relative focuser. Simulating absolute focuser behavior").
- Move outward 25 steps (`?position=25` from a fresh `Position=0`): INDI
  server shows `FOCUS_MOTION.FOCUS_OUTWARD=On` and
  `REL_FOCUS_POSITION.FOCUS_RELATIVE_POSITION=25`, no exception, `IsMoving`
  returns to `false` on completion, tracked `Position` updates to `25`.
- Move inward 15 steps (`?position=10`): same, with
  `FOCUS_MOTION.FOCUS_INWARD=On` and `REL_FOCUS_POSITION=15`.

No absolute INDI focuser was available on this rig to smoke-test end to end,
but the "Scope" section above is based on tracing the actual code paths
each focuser type executes, not just the HitecAstro DC's.
